### PR TITLE
removed default background on wails front-end

### DIFF
--- a/pkg/wails/wails.go
+++ b/pkg/wails/wails.go
@@ -19,7 +19,6 @@ func NewWailsApp(app *wApp.WalletApp, assets embed.FS) *application.Application 
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        app.Startup,
 		OnBeforeClose:    app.BeforeClose,
 		Bind: []interface{}{


### PR DESCRIPTION
We are removing the default background color in the wails front-end app.