### PR TITLE
wails : remove outline on input focus

### DIFF
--- a/wails-frontend/src/index.css
+++ b/wails-frontend/src/index.css
@@ -4,3 +4,9 @@
 
 @tailwind components;
 @tailwind utilities;
+
+/* global css */
+
+input:focus {
+  outline: none;
+}


### PR DESCRIPTION
We are removing default outline when input is in focus state.