### PR TITLE
Remove b64 logic from the sign function

### DIFF
--- a/internal/handler/wallet/errors.go
+++ b/internal/handler/wallet/errors.go
@@ -12,6 +12,7 @@ const (
 	errorDeleteFile
 	errorGetWallets
 	errorSignEmptyNickname
+	errorSignDecodeOperation
 	errorSignRead
 	errorSignLoadCache
 	errorSignGenerateCorrelationId

--- a/internal/handler/wallet/sign.go
+++ b/internal/handler/wallet/sign.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"bytes"
 	cryptorand "crypto/rand"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -72,7 +73,16 @@ func (s *walletSign) Handle(params operations.SignParams) middleware.Responder {
 		return resp
 	}
 
-	signature, err := wlt.Sign(params.Body.Operation)
+	op, err := base64.StdEncoding.DecodeString(params.Body.Operation.String())
+	if err != nil {
+		return operations.NewSignInternalServerError().WithPayload(
+			&models.Error{
+				Code:    errorSignDecodeOperation,
+				Message: "Error: while decoding operation.",
+			})
+	}
+
+	signature, err := wlt.Sign(op)
 	if err != nil {
 		return operations.NewSignInternalServerError().WithPayload(
 			&models.Error{

--- a/pkg/network/operation.go
+++ b/pkg/network/operation.go
@@ -3,7 +3,6 @@ package network
 import (
 	"fmt"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/massalabs/thyra-plugin-wallet/pkg/wallet"
 	sendOperation "github.com/massalabs/thyra/pkg/node/sendoperation"
 )
@@ -29,10 +28,8 @@ func SendOperation(wlt *wallet.Wallet, massaClient NodeFetcherInterface, operati
 		return nil, fmt.Errorf("Error while making operation: %w", err)
 	}
 
-	// sign the msg in base64
 	// TODO: we do not implement the handling of the correlation id for now
-	byteMsgB64 := strfmt.Base64(msg)
-	signature, err := wlt.Sign(&byteMsgB64)
+	signature, err := wlt.Sign(msg)
 	if err != nil {
 		return nil, fmt.Errorf("Error sign: %w", err)
 	}

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -267,8 +266,6 @@ func Load(nickname string) (*Wallet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting file path for '%s': %w", nickname, err)
 	}
-
-	log.Print(filePath)
 
 	if _, err := os.Stat(filePath); err != nil {
 		return nil, ErrorAccountNotFound(nickname)


### PR DESCRIPTION
Move b64 upwards in code that handles Sign request and replace string parameter of Wallet Sign function by byte array