### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/types/object/object.go
+++ b/pkg/types/object/object.go
@@ -4,6 +4,7 @@ package object
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/btcsuite/btcutil/base58"
 )
@@ -76,10 +77,8 @@ func (o *Object) Validate(lastVersion byte, expectedKinds ...Kind) error {
 		return ErrUnsupportedVersion
 	}
 
-	for _, kind := range expectedKinds {
-		if o.Kind == kind {
-			return nil
-		}
+	if slices.Contains(expectedKinds, o.Kind) {
+		return nil
 	}
 
 	return ErrInvalidType


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.